### PR TITLE
get the filename if only resized image is uploaded

### DIFF
--- a/django_file_form/uploader.py
+++ b/django_file_form/uploader.py
@@ -15,11 +15,17 @@ class FileFormUploadBackend(LocalUploadBackend):
     def upload_complete(self, request, filename, file_id, *args, **kwargs):
         result = super(FileFormUploadBackend, self).upload_complete(request, filename, file_id, *args, **kwargs)
 
+        # get the filename if only resized image is uploaded
+        if request.POST['qqfilename']:
+            original_filename = request.POST['qqfilename']
+        else:
+            original_filename = request.FILES['qqfile'].name
+
         values = dict(
             uploaded_file='%s/%s' % (self.UPLOAD_DIR, filename),
             file_id=file_id,
             form_id=request.POST['form_id'],
-            original_filename=request.FILES['qqfile'].name,
+            original_filename=original_filename,
         )
 
         field_name = request.POST.get('field_name', None)


### PR DESCRIPTION
if scaling is set in the Uploader options, the filename is stored in a different field.
example uploader options:
        scaling: {
            sendOriginal: false,
            sizes: [
                {name: "", maxSize: 1280}
            ]
        },