### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_file_form/management/commands/delete_unused_files.py
+++ b/django_file_form/management/commands/delete_unused_files.py
@@ -14,4 +14,4 @@ class Command(BaseCommand):
             if not deleted_files:
                 print('No files deleted')
             else:
-                print('Deleted files: %s' % ', '.join(deleted_files))
+                print('Deleted files: {0!s}'.format(', '.join(deleted_files)))

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -37,7 +37,7 @@ class UploadedFileManager(ModelManager):
 
     def get_for_file(self, filename):
         return self.try_get(
-            uploaded_file='temp_uploads/%s' % filename
+            uploaded_file='temp_uploads/{0!s}'.format(filename)
         )
 
 

--- a/django_file_form/uploader.py
+++ b/django_file_form/uploader.py
@@ -22,7 +22,7 @@ class FileFormUploadBackend(LocalUploadBackend):
             original_filename = request.FILES['qqfile'].name
 
         values = dict(
-            uploaded_file='%s/%s' % (self.UPLOAD_DIR, filename),
+            uploaded_file='{0!s}/{1!s}'.format(self.UPLOAD_DIR, filename),
             file_id=file_id,
             form_id=request.POST['form_id'],
             original_filename=original_filename,

--- a/testproject/django_file_form_example/tests.py
+++ b/testproject/django_file_form_example/tests.py
@@ -66,7 +66,7 @@ class FileFormWebTests(WebTest):
 
             uploaded_file = UploadedFile.objects.get(file_id=file_id)
             self.assertEqual(uploaded_file.original_filename, filename)
-            self.assertNotEqual(uploaded_file.uploaded_file.name, 'temp_uploads/%s' % filename)
+            self.assertNotEqual(uploaded_file.uploaded_file.name, 'temp_uploads/{0!s}'.format(filename))
 
             temp_filepath = media_root.joinpath(uploaded_file.uploaded_file.name)
             self.assertTrue(temp_filepath.exists())
@@ -91,7 +91,7 @@ class FileFormWebTests(WebTest):
             form.submit().follow()
 
             example = Example.objects.get(title='abc')
-            self.assertEqual(example.input_file.name, 'example/%s' % filename)
+            self.assertEqual(example.input_file.name, 'example/{0!s}'.format(filename))
 
             self.assertFalse(temp_filepath.exists())
             self.assertFalse(UploadedFile.objects.filter(file_id=file_id).exists())
@@ -117,7 +117,7 @@ class FileFormWebTests(WebTest):
             form.submit().follow()
 
             example = Example.objects.get(title='abc')
-            self.assertEqual(example.input_file.name, 'example/%s' % filename)
+            self.assertEqual(example.input_file.name, 'example/{0!s}'.format(filename))
 
             self.assertTrue(uploaded_file.exists())
         finally:
@@ -156,8 +156,8 @@ class FileFormWebTests(WebTest):
             example2 = Example2.objects.get(title='abc')
             files = example2.files.all()
             self.assertEqual(files.count(), 2)
-            self.assertEqual(six.text_type(files[0]), 'example/%s' % filename1)
-            self.assertEqual(six.text_type(files[1]), 'example/%s' % filename2)
+            self.assertEqual(six.text_type(files[0]), 'example/{0!s}'.format(filename1))
+            self.assertEqual(six.text_type(files[1]), 'example/{0!s}'.format(filename2))
 
             self.assertTrue(uploaded_file1.exists())
             self.assertTrue(uploaded_file2.exists())
@@ -183,7 +183,7 @@ class FileFormWebTests(WebTest):
             example2 = Example2.objects.get(title='abc')
             files = example2.files.all()
             self.assertEqual(files.count(), 1)
-            self.assertEqual(files[0].input_file.name, 'example/%s' % filename)
+            self.assertEqual(files[0].input_file.name, 'example/{0!s}'.format(filename))
 
             self.assertTrue(uploaded_file.exists())
         finally:
@@ -206,7 +206,7 @@ class FileFormWebTests(WebTest):
             form.submit().follow()
 
             example = Example.objects.get(title='aaa')
-            self.assertEqual(example.input_file.name, 'example/%s' % filename2)
+            self.assertEqual(example.input_file.name, 'example/{0!s}'.format(filename2))
         finally:
             remove_p(uploaded_file1)
             remove_p(uploaded_file2)
@@ -236,7 +236,7 @@ class FileFormWebTests(WebTest):
             example = Example.objects.create(title='abc', input_file=ContentFile('xyz', example_filename))
 
             # - get form
-            page = self.app.get('/existing/%d' % example.id)
+            page = self.app.get('/existing/{0:d}'.format(example.id))
             form = page.form
 
             self.assertTrue(example_file_path.exists())
@@ -301,7 +301,7 @@ class FileFormWebTests(WebTest):
 
     def delete_ajax_file(self, form, file_id):
         csrf_token = str(form['csrfmiddlewaretoken'].value)
-        delete_url = '%s/%s' % (form['delete_url'].value, file_id)
+        delete_url = '{0!s}/{1!s}'.format(form['delete_url'].value, file_id)
 
         response = self.app.post(
             delete_url,


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)