### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/testproject/django_file_form_example/tests.py
+++ b/testproject/django_file_form_example/tests.py
@@ -272,7 +272,7 @@ class FileFormWebTests(WebTest):
                 remove_p(temp_file_path)
 
     def test_unicode_filename(self):
-        filename = u'àęö%s' % get_random_id()
+        filename = u'àęö{0!s}'.format(get_random_id())
         temp_filepath = None
 
         form = self.app.get('/').form


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)