### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_file_form/util.py
+++ b/django_file_form/util.py
@@ -31,6 +31,5 @@ def load_class(setting_string):
         return import_string(getattr(conf, setting_string))
     except ImportError:
         raise ImproperlyConfigured(
-            "%s refers to a class '%s' that is not available" %
-            (setting_string, getattr(conf, setting_string))
+            "{0!s} refers to a class '{1!s}' that is not available".format(setting_string, getattr(conf, setting_string))
         )


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-file-form?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)