### PR TITLE
No index on the model

### DIFF
--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -60,7 +60,9 @@ class UploadedFile(models.Model):
     field_name = models.CharField(max_length=255, null=True, blank=True)
     file_id = models.CharField(max_length=40)
     form_id = models.CharField(max_length=40)
-
+    
+    # Query string to get back existing uploaded file is using form_id and field_name
+    unique_together = (("form_id", "field_name"),)
     objects = UploadedFileManager()
 
     def __str__(self):


### PR DESCRIPTION
Exemple of query

SELECT ••• FROM "django_file_form_uploadedfile" WHERE ("django_file_form_uploadedfile"."field_name" = '''photo_id_2''' AND "django_file_form_uploadedfile"."form_id" = '''a1ecf120-38d7-4272-8e37-f95ca8ffea0d''') ORDER BY "django_file_form_uploadedfile"."created" DESC LIMIT 1

Maybe a unique index on file_id as well ?