### PR TITLE
Allow other storage than filesystem storage

### DIFF
--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -70,13 +70,12 @@ class UploadedFile(models.Model):
     def __str__(self):
         return text_type(self.original_filename or '')
 
-    def delete(self, using=None):
-        super(UploadedFile, self).delete(using)
+    def delete(self, *args, **kwargs):
+        if self.uploaded_file and self.uploaded_file.storage.exists(self.uploaded_file.name):
+            self.uploaded_file.delete()
 
-        if self.uploaded_file:
-            if self.uploaded_file.storage.exists(self.uploaded_file.name):
-                self.uploaded_file.delete()
-
+        super(UploadedFile, self).delete(*args, **kwargs)
+                
     def must_be_deleted(self, now=None):
         now = now or timezone.now()
 

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -74,7 +74,8 @@ class UploadedFile(models.Model):
         super(UploadedFile, self).delete(using)
 
         if self.uploaded_file:
-            self.uploaded_file.delete()
+            if self.uploaded_file.storage.exists(self.uploaded_file.name):
+                self.uploaded_file.delete()
 
     def must_be_deleted(self, now=None):
         now = now or timezone.now()

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -74,9 +74,7 @@ class UploadedFile(models.Model):
         super(UploadedFile, self).delete(using)
 
         if self.uploaded_file:
-            if self.uploaded_file.exists():
-                self.uploaded_file.delete()
-
+            self.uploaded_file.delete()
 
     def must_be_deleted(self, now=None):
         now = now or timezone.now()

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -74,10 +74,9 @@ class UploadedFile(models.Model):
         super(UploadedFile, self).delete(using)
 
         if self.uploaded_file:
-            path = self.get_path()
+            if self.uploaded_file.exists():
+                self.uploaded_file.delete()
 
-            if path.exists():
-                path.unlink()
 
     def must_be_deleted(self, now=None):
         now = now or timezone.now()


### PR DESCRIPTION
I am using s3 storage and this storage does not have a path method and cannot use unlink
 delete() achieve the same thing but is compatible with any django storage 
we can check exists before with self.uploaded_file.storage.exists(self.uploaded_file.name)

Reference: 
from django.core.files.storage

    def path(self, name):
        """
        Returns a local filesystem path where the file can be retrieved using
        Python's built-in open() function. Storage systems that can't be
        accessed using open() should *not* implement this method.
        """
        raise NotImplementedError("This backend doesn't support absolute paths.")