### PR TITLE
Remove obsolete pathlib dependency if python >= 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages
 
-
 version = '0.4.2'
 
 setup(
@@ -14,7 +13,12 @@ setup(
     author_email='mbraak@ridethepony.nl',
     description='Django-file-form helps you to write forms with a pretty ajax upload',
     url='https://github.com/mbraak/django-file-form',
-    install_requires=['six', 'pathlib'],
+    install_requires=['six'],
+    extras_require={
+        ':python_version < "3.4"': [
+            'pathlib',
+        ],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -1,4 +1,4 @@
-pathlib==1.0.1
+pathlib==1.0.1; python_version < '3.4'
 pytz==2018.9
 six==1.12.0
 


### PR DESCRIPTION
These changes seem to do the trick