### PR TITLE
Relative file form upload dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Also see the testproject in the repository.
 Make sure the `FILE_FORM_UPLOAD_DIR` directory exists.
 
 ```
-temp_upload_dir = settings.FILE_FORM_UPLOAD_DIR
+temp_upload_dir = os.path.join(settings.MEDIA_ROOT,  settings.FILE_FORM_UPLOAD_DIR)
 
 if not os.path.exists(temp_upload_dir):
   os.mkdir(temp_upload_dir)
@@ -185,7 +185,7 @@ Settings in `settings.py`:
 
 * **FILE_FORM_UPLOAD_DIR** (string):
   * The directory for the temporary uploads.
-  * The setting is not full path, but must be a subdirectory of `MEDIA_ROOT`.
+  * The setting is relative to `MEDIA_ROOT`.
   * The default is `temp_uploads`.
 
 * **FILE_FORM_FILE_STORAGE** (string):
@@ -217,6 +217,9 @@ initFormSet(
 * Also see the `testproject` directory in the repository for an example.
 
 ## Changelog
+
+* **development**
+  * Issue #266: Allow relative FILE_FORM_UPLOAD_DIR setting (thanks to Bo Peng)
 
 * **2.0.3 (15 february 2020)**
   * Issue #237: using with form set (thanks to Juan Carlos Carvajal)

--- a/django_file_form/conf.py
+++ b/django_file_form/conf.py
@@ -1,8 +1,6 @@
-import os
 from django.conf import settings
 
 
-UPLOAD_DIR = getattr(settings, 'FILE_FORM_UPLOAD_DIR', os.path.join(settings.MEDIA_ROOT, 'temp_uploads'))
 FILE_STORAGE = getattr(settings, 'FILE_FORM_FILE_STORAGE', 'django.core.files.storage.FileSystemStorage')
 
 # in bytes, default is 4 GB

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -7,7 +7,7 @@ from django.core.files import uploadedfile
 from django.db import models
 from django.utils import timezone
 from . import conf
-from .util import ModelManager, load_class
+from .util import ModelManager, load_class, get_upload_path
 
 
 class UploadedFileManager(ModelManager):
@@ -21,7 +21,7 @@ class UploadedFileManager(ModelManager):
                 if delete:
                     t.delete()
 
-        temp_path = Path(settings.MEDIA_ROOT).joinpath(conf.UPLOAD_DIR)
+        temp_path = get_upload_path()
 
         for f in temp_path.iterdir():
             basename = f.name
@@ -35,7 +35,7 @@ class UploadedFileManager(ModelManager):
         return deleted_files
 
     def get_for_file(self, filename):
-        path = Path(conf.UPLOAD_DIR).joinpath(filename)
+        path = get_upload_path().joinpath(filename)
         return self.try_get(uploaded_file=path)
 
 
@@ -46,7 +46,7 @@ def get_storage():
 
 
 def upload_to(instance, filename):
-    return str(conf.UPLOAD_DIR)
+    return str(get_upload_path())
 
 
 class UploadedFile(models.Model):

--- a/django_file_form/util.py
+++ b/django_file_form/util.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.db import models
 from django.utils.module_loading import import_string
@@ -38,3 +40,13 @@ def check_permission(request):
 
     if must_login and not request.user.is_authenticated:
         raise PermissionDenied()
+
+
+def get_upload_path():
+    default_upload_dir = 'temp_uploads'
+    upload_path = Path(getattr(settings, 'FILE_FORM_UPLOAD_DIR', default_upload_dir))
+
+    if upload_path.is_absolute():
+        return upload_path
+    else:
+        return Path(settings.MEDIA_ROOT).joinpath(upload_path)

--- a/django_file_form/views/tus.py
+++ b/django_file_form/views/tus.py
@@ -141,7 +141,7 @@ class TusUpload(View):
         file_offset = int(request.META.get("HTTP_UPLOAD_OFFSET", 0))
         chunk_size = int(request.META.get("CONTENT_LENGTH", 102400))
 
-        upload_file_path = Path(conf.UPLOAD_DIR).joinpath(resource_id)
+        upload_file_path = get_upload_path().joinpath(resource_id)
         if filename is None or not upload_file_path.exists():
             response.status_code = 410
             return response

--- a/django_file_form/views/tus.py
+++ b/django_file_form/views/tus.py
@@ -11,7 +11,7 @@ from django.views.generic import View
 
 from django_file_form import conf
 from django_file_form.models import UploadedFile
-from django_file_form.util import check_permission
+from django_file_form.util import check_permission, get_upload_path
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ class TusUpload(View):
         cache.add("tus-uploads/{}/metadata".format(resource_id), metadata, conf.TIMEOUT)
 
         try:
-            with Path(conf.UPLOAD_DIR).joinpath(resource_id).open("wb") as f:
+            with Path(get_upload_path()).joinpath(resource_id).open("wb") as f:
                 pass
         except IOError as e:
             logger.error("Unable to create file: {}".format(e), exc_info=True, extra={
@@ -192,7 +192,7 @@ class TusUpload(View):
 
         logger.info(f"TUS delete resource_id={resource_id}")
 
-        upload_file_path = Path(conf.UPLOAD_DIR).joinpath(resource_id)
+        upload_file_path = get_upload_path().joinpath(resource_id)
 
         if upload_file_path.exists():
             upload_file_path.unlink()

--- a/testproject/django_file_form_example/tests/test_model.py
+++ b/testproject/django_file_form_example/tests/test_model.py
@@ -8,11 +8,11 @@ from django.test import TestCase
 from django.core.management import call_command
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.test.utils import captured_stdout
+from django.test.utils import captured_stdout, override_settings
 
 from django_file_form_example.test_utils import get_random_id, encode_datetime, remove_p
 from django_file_form.models import UploadedFile
-from django_file_form.util import get_list, load_class
+from django_file_form.util import get_list, load_class, get_upload_path
 
 
 media_root = Path(settings.MEDIA_ROOT)
@@ -99,3 +99,16 @@ class UtilTests(TestCase):
             expected_message = r"FILE_STORAGE refers to a class 'django_file_form\.DoesNotExist' that is not available"
             with self.assertRaisesRegex(ImproperlyConfigured, expected_message):
                 load_class('FILE_STORAGE', mock_conf)
+
+
+class ConfTest(TestCase):
+    @override_settings(FILE_FORM_UPLOAD_DIR='/absolute/path/')
+    def test_get_upload_path_absolute(self):
+        self.assertEqual(str(get_upload_path()), '/absolute/path')
+
+    @override_settings(FILE_FORM_UPLOAD_DIR='relative/path/')
+    def test_get_upload_path_relative(self):
+        self.assertEqual(
+            str(get_upload_path()),
+            str(Path(settings.MEDIA_ROOT).joinpath('relative/path'))
+        )

--- a/testproject/django_file_form_example/views.py
+++ b/testproject/django_file_form_example/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.views import generic
 from django.urls import reverse
 from formtools.wizard.views import SessionWizardView
-from django_file_form import conf
+from django_file_form.util import get_upload_path
 
 from . import forms
 
@@ -51,7 +51,7 @@ class MultipleWithoutJsExampleView(MultipleExampleView):
 
 class WizardExampleview(SessionWizardView):
     form_list = [forms.MultipleFileExampleForm, forms.WizardStepForm]
-    file_storage = FileSystemStorage(location=conf.UPLOAD_DIR)
+    file_storage = FileSystemStorage(location=get_upload_path())
     template_name = 'wizard.html'
 
     def done(self, form_list, **kwargs):

--- a/testproject/testproject/settings_default.py
+++ b/testproject/testproject/settings_default.py
@@ -66,8 +66,6 @@ MEDIA_ROOT, STATIC_ROOT = resolve_paths()
 
 create_media_paths(Path(MEDIA_ROOT))
 
-FILE_FORM_UPLOAD_DIR = Path(MEDIA_ROOT).joinpath('temp_uploads')
-
 USE_TZ = True
 
 TEMPLATES = [


### PR DESCRIPTION
The `FILE_FORM_UPLOAD_DIR` expects a relative path; it's relative to the media path.

* Previously an absolute path was expected. This is still supported.
* Note that Django requires the path to be relative to the media path.

Also see issue #266 