### PR TITLE
Show file size info in file list

### DIFF
--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -94,4 +94,4 @@ class UploadedFileWithId(uploadedfile.UploadedFile):
         self.size = os.path.getsize(self.file.name)
 
     def get_values(self):
-        return dict(id=self.file_id, name=self.name)
+        return dict(id=self.file_id, name=self.name, size=self.size)

--- a/frontend/file_form.js
+++ b/frontend/file_form.js
@@ -22,9 +22,9 @@ class RenderUploadFile {
     return div;
   };
 
-  addUploadedFile(filename, uploadIndex) {
+  addUploadedFile(filename, uploadIndex, filesize) {
     this.addFile(filename, uploadIndex);
-    this.setSuccess(uploadIndex);
+    this.setSuccess(uploadIndex, filesize);
   }
 
   addNewUpload(filename, uploadIndex) {
@@ -95,11 +95,18 @@ class RenderUploadFile {
     return this.container.querySelector(`.dff-file-id-${index}`);
   }
 
-  setSuccess(index) {
+  setSuccess(index, size) {
     const { translations } = this;
 
     const el = this.findFileDiv(index);
     el.classList.add("dff-upload-success");
+
+    const fileSizeInfo = document.createElement("span");
+    fileSizeInfo.innerHTML = size;
+    fileSizeInfo.className = "dff-filesize";
+    fileSizeInfo.setAttribute("data-index", index);
+
+    el.appendChild(fileSizeInfo);
 
     const deleteLink = document.createElement("a");
     deleteLink.innerHTML = translations.Delete;
@@ -216,7 +223,7 @@ class UploadFile {
     const { multiple, renderer } = this;
 
     const addInitialFile = (file, i) => {
-      renderer.addUploadedFile(file.name, i);
+      renderer.addUploadedFile(file.name, i, file.size);
       this.uploads.push({ url: `${this.uploadUrl}${file.id}` });
     };
 
@@ -252,7 +259,7 @@ class UploadFile {
         metadata: { fieldName, filename, formId },
         onError: () => this.handleError(uploadIndex),
         onProgress: (bytesUploaded, bytesTotal) => this.handleProgress(uploadIndex, bytesUploaded, bytesTotal),
-        onSuccess: () => this.handleSuccess(uploadIndex)
+        onSuccess: () => this.handleSuccess(uploadIndex, upload.file.size)
       });
 
       upload.start();
@@ -294,11 +301,11 @@ class UploadFile {
     this.renderer.setError(uploadIndex);
   };
 
-  handleSuccess = uploadIndex => {
+  handleSuccess = (uploadIndex, uploadedSize) => {
     const { renderer } = this;
 
     renderer.clearInput();
-    renderer.setSuccess(uploadIndex);
+    renderer.setSuccess(uploadIndex, uploadedSize);
   };
 
   handleDelete(uploadIndex) {

--- a/frontend/file_form.js
+++ b/frontend/file_form.js
@@ -95,6 +95,16 @@ class RenderUploadFile {
     return this.container.querySelector(`.dff-file-id-${index}`);
   }
 
+  // https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
+  formatBytes(bytes, decimals) {
+    if (bytes == 0) return '0 Bytes';
+    var k = 1024,
+        dm = decimals <= 0 ? 0 : decimals || 2,
+        sizes = ['Bytes', 'KB', 'MB', 'GB'],
+        i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  }
+
   setSuccess(index, size) {
     const { translations } = this;
 
@@ -102,9 +112,8 @@ class RenderUploadFile {
     el.classList.add("dff-upload-success");
 
     const fileSizeInfo = document.createElement("span");
-    fileSizeInfo.innerHTML = size;
+    fileSizeInfo.innerHTML = this.formatBytes(size, 2);
     fileSizeInfo.className = "dff-filesize";
-    fileSizeInfo.setAttribute("data-index", index);
 
     el.appendChild(fileSizeInfo);
 


### PR DESCRIPTION
#275 

@mbraak The patch more or less works but I did not check corner cases and/or errors. Also, I list the bytes directly but there should be plenty of functions to translate bytes to `2.1M`, `5.3K` etc. I will add that if you think the bulk part of the PR is correct.