### PR TITLE
Make strings discoverables from django makemessages command and related

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ testproject/*.db
 testproject/*.log
 testproject/media
 testproject/t
+Pipfile
+Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -301,6 +301,29 @@ initFormSet(
 * Note that the default form set prefix is `form`.
 * Also see the `testproject` directory in the repository for an example.
 
+## Translate
+
+To update a translation or add new language 
+
+Fork this repo as usual
+
+```shell 
+# enter in project folder
+cd django-file-form
+
+# create virtualenv (example using pipenv)
+pipenv install --python=3 -r testproject/requirements.txt
+
+# enter in venv shell
+pipenv shell
+
+# update po file for your language
+django-admin makemessages -l fr
+```
+
+You can now edit generated po file and commit your changes as usual
+
+
 ## Changelog
 
 * **development**

--- a/django_file_form/locale/fr/LC_MESSAGES/django.po
+++ b/django_file_form/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,39 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-10 10:51+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: widgets.py:12
+msgid "Cancel"
+msgstr "Annuler"
+
+#: widgets.py:13
+msgid "Delete"
+msgstr "Supprimer"
+
+#: widgets.py:14
+msgid "Delete failed"
+msgstr "Échec de la supression"
+
+#: widgets.py:15
+msgid "Upload failed"
+msgstr "Échec du téléversement"
+
+#: widgets.py:16
+msgid "Drop your files here"
+msgstr "Déposez vos fichiers ici"

--- a/django_file_form/locale/nl/LC_MESSAGES/django.po
+++ b/django_file_form/locale/nl/LC_MESSAGES/django.po
@@ -1,11 +1,19 @@
+#: widgets.py:12
 msgid "Cancel"
 msgstr "Annuleren"
 
+#: widgets.py:13
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: widgets.py:14
 msgid "Delete failed"
 msgstr "Verwijderen mislukt"
 
+#: widgets.py:15
 msgid "Upload failed"
 msgstr "Upload mislukt"
 
+#: widgets.py:16
 msgid "Drop your files here"
 msgstr "Sleep uw bestanden"

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -3,18 +3,17 @@ import json
 from django.forms import ClearableFileInput
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.utils import translation
+from django.utils.translation import gettext as _
 
 from django_file_form.util import get_list
 from django_file_form.models import PlaceholderUploadedFile
 
-def get_translations():
-    keys = ['Cancel', 'Delete', 'Delete failed', 'Upload failed', 'Drop your files here']
 
-    return {
-        key: translation.gettext(key) for key in keys
-    }
-
+TRANSLATIONS = {'Cancel': _('Cancel'),
+                'Delete': _('Delete'),
+                'Delete failed': _('Delete failed'),
+                'Upload failed': _('Upload failed'),
+                'Drop your files here': _('Drop your files here')}
 
 def get_uploaded_files(value):
     if not value:
@@ -37,7 +36,7 @@ class UploadWidgetMixin(ClearableFileInput):
                 'django_file_form/upload_widget.html',
                 dict(
                     input=upload_input,
-                    translations=json.dumps(get_translations()),
+                    translations=json.dumps(TRANSLATIONS),
                     uploaded_files=json.dumps(get_uploaded_files(value)),
                 )
             )


### PR DESCRIPTION
Hello,
This pr is about translation do the following

- move translatables strings to static dict to make them discoverable by makemessages command
- add missing "delete" translation for nl language
- add french translation
- add a short howto translate paragraph to the README
- add pipenv related files to .gitignore

I would have preferred to do several pr but I discovered that it requires moving the commits in different branches. I let you have a look and tell me if you don't want to integrate everything in which case I can split the pr
Simon