### PR TITLE
Passing metadata between front and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,24 +268,24 @@ file = UploadedFileField(accept='image/*,.pdf')
 
 **6 Additional file metadata
 
-If you want to add and maitain additional metadata such as short descriptions and
+If you want to add and maintain additional metadata such as short descriptions and
 categories of uploaded files, you can use the `.metadata` field of uploaded files.
 More specifically,
 
-1. There is a hidden field called `meta` (with form specific prefix) with its `data`
+1. There is a hidden field called `metadata` (with form specific prefix) with its `data`
    being the `JSON.dump`ed meta data of all files. The data should be in the format of
    ```
    {
       'filename1': value1,
-      'filename2': value2,
+      'filename2': value2
    }
    ```
 
-2. Using the event mechanism of `django-file-form` to add your own widgets and functions
-   to update the `data` of this field.
+2. Listen to events triggered after the additional and removal of file list to add your
+  own widgets and functions to update the `data` of this hidden field.
 
-`django-file-form` retrieves the data and assign them to returned file objects (could be
-of placeholder and other types) as `f.meta`.
+`django-file-form` retrieves the data and assign them to returned file objects with matching
+filename (could be of placeholder and other types) as `f.metadata`.
 
 
 ## Upgrade from version 1.0 (to 2.0)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Features:
 * Supports single and multiple file upload.
 * Supports edition of uploaded files.
 * Supports upload directly to AWS S3 compatible storages.
+* Supports frontend events for the addition and removal of files.
+* Supports addition of arbitrary file meta data and related widgets.
 
 The project is hosted on [github](https://github.com/mbraak/django-file-form).
 
@@ -263,6 +265,28 @@ You can add an accept attribute to the file input using the `accept` parameter o
 ```
 file = UploadedFileField(accept='image/*,.pdf')
 ```
+
+**6 Additional file metadata
+
+If you want to add and maitain additional metadata such as short descriptions and
+categories of uploaded files, you can use the `.metadata` field of uploaded files.
+More specifically,
+
+1. There is a hidden field called `meta` (with form specific prefix) with its `data`
+   being the `JSON.dump`ed meta data of all files. The data should be in the format of
+   ```
+   {
+      'filename1': value1,
+      'filename2': value2,
+   }
+   ```
+
+2. Using the event mechanism of `django-file-form` to add your own widgets and functions
+   to update the `data` of this field.
+
+`django-file-form` retrieves the data and assign them to returned file objects (could be
+of placeholder and other types) as `f.meta`.
+
 
 ## Upgrade from version 1.0 (to 2.0)
 

--- a/django_file_form/forms.py
+++ b/django_file_form/forms.py
@@ -21,6 +21,7 @@ class FileFormMixin(object):
         self.add_hidden_field('form_id', uuid.uuid4())
         self.add_hidden_field('upload_url', self.get_upload_url())
         self.add_placeholder_inputs()
+        self.add_metadata_inputs()
 
     def add_hidden_field(self, name, initial):
         self.fields[name] = CharField(widget=HiddenInput, initial=initial, required=False)
@@ -88,3 +89,16 @@ class FileFormMixin(object):
         initial_values = get_list(self.initial.get(field_name, []))
 
         return [value.get_values() for value in initial_values if getattr(value, 'is_placeholder')]
+
+
+    def add_metadata_inputs(self):
+        for field_name in self.file_form_field_names():
+            metadata_field_name = f'{field_name}-metadata'
+            self.add_hidden_field(
+                metadata_field_name,
+                json.dumps(self.get_metadata_for_field(field_name))
+            )
+
+    def get_metadata_for_field(self, field_name):
+        initial_values = get_list(self.initial.get(field_name, []))
+        return {value.name: value.metadata for value in initial_values}

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -91,7 +91,7 @@ class UploadedFile(models.Model):
 
 
 class UploadedFileWithId(uploadedfile.UploadedFile):
-    def __init__(self, file_id, **kwargs):
+    def __init__(self, file_id, metadata=None, **kwargs):
         super(UploadedFileWithId, self).__init__(**kwargs)
 
         self.file_id = file_id
@@ -99,13 +99,14 @@ class UploadedFileWithId(uploadedfile.UploadedFile):
 
         self.is_placeholder = False
         self.is_s3direct = False
+        self.metadata = metadata
 
     def get_values(self):
-        return dict(id=self.file_id, name=self.name, size=self.size)
+        return dict(id=self.file_id, name=self.name, size=self.size, metadata=self.metadata)
 
 
 class PlaceholderUploadedFile(object):
-    def __init__(self, name, file_id=None, size=None):
+    def __init__(self, name, file_id=None, size=None, metadata=None):
         self.name = name
         self.file_id = file_id or uuid.uuid4().hex
         if size is None:
@@ -115,15 +116,17 @@ class PlaceholderUploadedFile(object):
 
         self.is_placeholder = True
         self.is_s3direct = False
+        self.metadata = metadata
 
     def get_values(self):
-        return dict(id=self.file_id, placeholder=True, name=self.name, size=self.size)
+        return dict(id=self.file_id, placeholder=True, name=self.name,
+            size=self.size, metadata=self.metadata)
 
 try:
     from storages.backends.s3boto3 import S3Boto3Storage, S3Boto3StorageFile
 
     class S3UploadedFileWithId(S3Boto3StorageFile):
-        def __init__(self, file_id, name, original_name, size, **kwargs):
+        def __init__(self, file_id, name, original_name, size, metadata=None, **kwargs):
             super(S3UploadedFileWithId, self).__init__(name=name, mode='rb',
                 storage=S3Boto3Storage(), **kwargs)
             self.file_id = file_id
@@ -133,9 +136,11 @@ try:
             # for validation
             self.is_placeholder = False
             self.is_s3direct = True
+            self.metadata = metadata
 
         def get_values(self):
-            return dict(id=self.file_id, placeholder=False, name=self.name, size=self.size)
+            return dict(id=self.file_id, placeholder=False, name=self.name,
+                size=self.size, metadata=self.metadata)
 
 except ImproperlyConfigured:
     # S3 is an optional feature

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -55,15 +55,15 @@ def get_s3_uploaded_files(data, field_name):
         ]
 
 def get_file_meta(data, field_name):
-    meta_field_name = field_name + '-meta'
+    meta_field_name = field_name + '-metadata'
     value = data.get(meta_field_name)
-
     if not value:
         return {}
     try:
         res = json.loads(value)
         if not isinstance(res, dict):
             return {}
+        return res
     except Exception:
         return {}
 

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -54,6 +54,19 @@ def get_s3_uploaded_files(data, field_name):
             for s3uploaded in json.loads(value)
         ]
 
+def get_file_meta(data, field_name):
+    meta_field_name = field_name + '-meta'
+    value = data.get(meta_field_name)
+
+    if not value:
+        return {}
+    try:
+        res = json.loads(value)
+        if not isinstance(res, dict):
+            return {}
+    except Exception:
+        return {}
+
 class UploadWidgetMixin(ClearableFileInput):
     def render(self, name, value, attrs=None, renderer=None):
         upload_input = super(UploadWidgetMixin, self).render(name, value, attrs, renderer)
@@ -78,12 +91,21 @@ class UploadWidget(UploadWidgetMixin, ClearableFileInput):
         else:
             placeholders = get_placeholder_files(data, name)
             s3uploaded = get_s3_uploaded_files(data, name)
-            return placeholders[0] if placeholders else (s3uploaded[0] if s3uploaded else None)
+            metadata = get_file_meta(data, name)
+            obj = placeholders[0] if placeholders else (s3uploaded[0] if s3uploaded else None)
+            if obj is not None and obj.name in metadata:
+                obj.metadata = metadata[obj.name]
+            return obj
 
 class UploadMultipleWidget(UploadWidget):
     def value_from_datadict(self, data, files, name):
         if hasattr(files, 'getlist'):
-            return files.getlist(name) + get_placeholder_files(data, name) + get_s3_uploaded_files(data, name)
+            metadata = get_file_meta(data, name)
+            objs = files.getlist(name) + get_placeholder_files(data, name) + get_s3_uploaded_files(data, name)
+            for obj in objs:
+                if obj.name in metadata:
+                    obj.metadata = metadata[obj.name]
+            return objs
         else:
             # NB: django-formtools wizard uses dict instead of MultiValueDict
             return super(UploadMultipleWidget, self).value_from_datadict(data, files, name)

--- a/testproject/django_file_form_example/forms.py
+++ b/testproject/django_file_form_example/forms.py
@@ -114,6 +114,19 @@ class PlaceholderExampleForm(BaseForm):
         self.delete_temporary_files()
 
 
+
+class PlaceholderWidgetExampleForm(PlaceholderExampleForm):
+
+    def save(self):
+        example = Example2.objects.create(
+            title=self.cleaned_data['title']
+        )
+
+        for f in self.cleaned_data['input_file']:
+            assert f.metadata is not None
+
+        self.delete_temporary_files()
+
 class WithAcceptExampleForm(BaseForm):
     prefix = 'example'
     input_file = MultipleUploadedFileField(accept='image/*')

--- a/testproject/django_file_form_example/static/example_form_custom_widget.js
+++ b/testproject/django_file_form_example/static/example_form_custom_widget.js
@@ -1,0 +1,55 @@
+const eventEmitter = new EventEmitter3();
+
+function getMetaDataField(fieldName) {
+  // no consideration of prefix??
+  // not sure how to use functions in .utils
+  const name = fieldName + '-metadata';
+  const form = document.getElementById("example-form");
+  return field = form.querySelector(`[name="${name}"]`);
+}
+
+function descriptionChanged(evt) {
+  let field = getMetaDataField(evt.target.getAttribute('fieldName'));
+  let descriptions = document.getElementsByClassName('dff-description');
+  let data = {}
+  for (let i = 0; i < descriptions.length; ++i) {
+    let desc = descriptions[i];
+    data[desc.getAttribute('fileName')] = {
+      'description': desc.value
+    }
+  }
+  field.value = JSON.stringify(data);
+}
+
+eventEmitter.on('addUpload', ({ element, fieldName, upload }) => {
+  // console.log('addUpload', element, fieldName, upload);
+  let field = getMetaDataField(fieldName);
+  if (!field || !field.value) {
+    return;
+  }
+  let metadata = JSON.parse(field.value);
+  // add a widget
+  let descElem = document.createElement('input');
+  descElem.value = metadata[upload.name] ? metadata[upload.name]['description'] : '';
+
+  descElem.className = 'dff-description';
+  descElem.setAttribute('fileName', upload.name);
+  descElem.setAttribute('fieldName', fieldName);
+  descElem.addEventListener('change', descriptionChanged);
+  element.appendChild(descElem);
+});
+
+eventEmitter.on('removeUpload', ({ element, fieldName, upload }) => {
+  // do not need to update hidden data since returned metadata will be ignored
+});
+
+initUploadFields(
+    document.getElementById("example-form"),
+    {
+      eventEmitter,
+      prefix: "example",
+      retryDelays: [],
+      skipRequired: true,
+      supportDropArea: true
+    }
+);

--- a/testproject/django_file_form_example/urls.py
+++ b/testproject/django_file_form_example/urls.py
@@ -17,4 +17,5 @@ urlpatterns = (
     path('s3multiple', views.S3ExampleView.as_view(), name='s3_example'),
     path('s3placeholder', views.S3PlaceholderExampleView.as_view(), name='s3_example'),
     path('accept', views.WithAcceptExample.as_view(), name='with_accept_example'),
+    path('custom_widget', views.WithCustomWidgetExample.as_view(), name='with_custom_widget')
 )

--- a/testproject/django_file_form_example/views.py
+++ b/testproject/django_file_form_example/views.py
@@ -113,9 +113,9 @@ class WithAcceptExample(BaseFormView):
     form_class = forms.WithAcceptExampleForm
 
 
-class WithCustomWidgetExample(BaseFormView):
+class WithCustomWidgetExample(PlaceholderView):
     custom_js_file = 'example_form_custom_widget.js'
-    form_class = forms.PlaceholderExampleForm
+    form_class = forms.PlaceholderWidgetExampleForm
 
     def get_initial(self):
         initial = super(WithCustomWidgetExample, self).get_initial()

--- a/testproject/django_file_form_example/views.py
+++ b/testproject/django_file_form_example/views.py
@@ -113,6 +113,22 @@ class WithAcceptExample(BaseFormView):
     form_class = forms.WithAcceptExampleForm
 
 
+class WithCustomWidgetExample(BaseFormView):
+    custom_js_file = 'example_form_custom_widget.js'
+    form_class = forms.PlaceholderExampleForm
+
+    def get_initial(self):
+        initial = super(WithCustomWidgetExample, self).get_initial()
+
+        if self.request.method == 'GET':
+            initial['input_file'] = [
+                PlaceholderUploadedFile('test_placeholder1.txt', size=1024, metadata={'description': 'placeholder 1'}),
+                PlaceholderUploadedFile('test_placeholder2.txt', size=2048, metadata={'description': 'placeholder 2'})
+            ]
+
+        return initial
+
+
 def permission_denied(request, exception):
     return HttpResponseForbidden(
         json.dumps(dict(status='permission denied')),


### PR DESCRIPTION
This is a proof-of-concept PR and I can refine later. I forked it from the `add-event` branch because I need the event listener.

Basically,

1. A hidden field `-metadata` is passed to frontend.
2. All model objects now have a `metadata` field.
3. User code uses the event mechanism to add additional widgets, with event listener to update the hidden field
4. metadata is passed to the backend, and distributed to all `File` objects.

#314 and #321.
