### PR TITLE
Allow define s3_upload_dir in form class

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,14 +232,15 @@ CSP_CONNECT_SRC = ("'self'", AWS_S3_ENDPOINT_URL)
 ```
 where `AWS_S3_ENDPOINT_URL` is the AWS endpoint defined above.
 
-Then, you will need to pass
+Then, you will need to define
 
   ```
   s3_upload_dir = "user_or_form_specific_id"
   ```
 
-to the constructor of the form to inform the frontend to use the AJAX uploader for S3.
-The files will be uploaded to
+in the form class or passed parameter `s3_upload_dir` to the constructor of the
+form to inform the frontend to use the AJAX uploader for S3. The files will be
+uploaded to
 
 ```
 ${FILE_FORM_UPLOAD_DIR}/${s3_upload_dir}/

--- a/django_file_form/forms.py
+++ b/django_file_form/forms.py
@@ -11,7 +11,8 @@ from .util import get_list
 
 class FileFormMixin(object):
     def __init__(self, *args, **kwargs):
-        s3_upload_dir = kwargs.pop('s3_upload_dir', None)
+        s3_upload_dir = kwargs.pop('s3_upload_dir',
+            self.s3_upload_dir if hasattr(self, 's3_upload_dir') else None)
         super(FileFormMixin, self).__init__(*args, **kwargs)
 
         if s3_upload_dir is not None:

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -150,6 +150,6 @@ try:
         def get_values(self):
             return dict(id=self.file_id, placeholder=False, name=self.name, size=self.size)
 
-except ImproperlyConfigured:
+except (ImportError, ImproperlyConfigured):
     # S3 is an optional feature
     pass

--- a/django_file_form/models.py
+++ b/django_file_form/models.py
@@ -9,7 +9,6 @@ from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.utils import timezone
 from django.utils.module_loading import import_string
-from storages.utils import setting
 
 from .util import ModelManager, get_upload_path
 
@@ -123,6 +122,7 @@ class PlaceholderUploadedFile(object):
 
 try:
     from storages.backends.s3boto3 import S3Boto3Storage, S3Boto3StorageFile
+    from storages.utils import setting
 
     class S3UploadedFileWithId(S3Boto3StorageFile):
         def __init__(self, file_id, name, original_name, size, **kwargs):
@@ -151,5 +151,6 @@ try:
             return dict(id=self.file_id, placeholder=False, name=self.name, size=self.size)
 
 except (ImportError, ImproperlyConfigured):
-    # S3 is an optional feature
-    pass
+    # S3 is an optional feature but we keep the symbol
+    class S3UploadedFileWithId(object):
+        pass

--- a/django_file_form/urls.py
+++ b/django_file_form/urls.py
@@ -1,12 +1,20 @@
 from django.urls import path
 from .views.tus import TusUpload
-from .views.s3multipart import s3multipart
 
-urlpatterns = (
+tus_patterns = [
     path('upload/', TusUpload.as_view(), name='tus_upload'),
-    path('upload/<str:resource_id>', TusUpload.as_view(), name='tus_upload_chunks'),
-    path('s3upload/', s3multipart.create_multipart_upload, name='create_multipart_upload'),
-    path('s3upload/<upload_id>/', s3multipart.get_parts_or_abort_upload, name='get_parts_or_abort_upload'),
-    path('s3upload/<upload_id>/<int:part_number>', s3multipart.sign_part_upload, name='sign_part_upload'),
-    path('s3upload/<upload_id>/complete', s3multipart.complete_multipart_upload, name='complete_multipart_upload'),
-)
+    path('upload/<str:resource_id>', TusUpload.as_view(), name='tus_upload_chunks')
+]
+
+try:
+    from .views.s3multipart import s3multipart
+    s3_patterns = [
+        path('s3upload/', s3multipart.create_multipart_upload, name='create_multipart_upload'),
+        path('s3upload/<upload_id>/', s3multipart.get_parts_or_abort_upload, name='get_parts_or_abort_upload'),
+        path('s3upload/<upload_id>/<int:part_number>', s3multipart.sign_part_upload, name='sign_part_upload'),
+        path('s3upload/<upload_id>/complete', s3multipart.complete_multipart_upload, name='complete_multipart_upload'),
+    ]
+except ImportError:
+    s3_patterns = []
+
+urlpatterns = tus_patterns + s3_patterns

--- a/testproject/django_file_form_example/forms.py
+++ b/testproject/django_file_form_example/forms.py
@@ -69,6 +69,7 @@ class MultipleFileExampleForm(BaseForm):
 class S3ExampleForm(BaseForm):
     prefix = 'example'
     input_file = MultipleUploadedFileField()
+    s3_upload_dir = 's3_example'
 
     def save(self):
         example = Example2.objects.create(

--- a/testproject/django_file_form_example/urls.py
+++ b/testproject/django_file_form_example/urls.py
@@ -15,6 +15,6 @@ urlpatterns = (
     path('login/', LoginView.as_view(template_name='admin/login.html')),
     path('placeholder', views.PlaceholderView.as_view(), name='placeholder_example'),
     path('s3multiple', views.S3ExampleView.as_view(), name='s3_example'),
-    path('s3placeholder', views.S3PlaceholderExampleView.as_view(), name='s3_example'),
+    path('s3placeholder', views.S3PlaceholderExampleView.as_view(), name='s3_placeholder_example'),
     path('accept', views.WithAcceptExample.as_view(), name='with_accept_example'),
 )

--- a/testproject/django_file_form_example/views.py
+++ b/testproject/django_file_form_example/views.py
@@ -102,7 +102,6 @@ class PlaceholderView(BaseFormView):
 
 class S3ExampleView(BaseFormView):
     form_class = forms.S3ExampleForm
-    s3_upload_dir = 's3_example'
 
 
 class S3PlaceholderExampleView(PlaceholderView):


### PR DESCRIPTION
Currently `s3_upload_dir` is passed through the constructor of class, which is very flexible but the constructor of forms are rarely called directly and we had to use `get_form_kwargs` to pass `s3_upload_dir` from view to form.

This patch allows users to define `s3_upload_dir` in the form class directly, similar to `prefix`, which can be easier to use. One of the tests is changed to specify `s3_upload_dir` in this way. 

This patch also allows `django-file-form` to be used without `django-storages`, which helps backward compatibility.