### PR TITLE
Override get_context instead of render for the rendering of widget

### DIFF
--- a/django_file_form/templates/django_file_form/upload_widget.html
+++ b/django_file_form/templates/django_file_form/upload_widget.html
@@ -7,6 +7,6 @@
         {% endif %}
         data-translations="{{ translations }}"
     >
-        {{ input }}
+        {% include "django/forms/widgets/input.html" %}
     </div>
 </div>

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -89,10 +89,14 @@ def get_file_meta(data: QueryDict, field_name: str):
 
 
 class BaseUploadWidget(ClearableFileInput):
+    template_name = "django_file_form/upload_widget.html"
+
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context['translations'] = json.dumps(TRANSLATIONS)
         context['uploaded_files'] = json.dumps(get_uploaded_files(value))
+        # for backward compatibility
+        context['input'] = super().render(name, value, attrs, None)
         return context
 
 

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -89,24 +89,11 @@ def get_file_meta(data: QueryDict, field_name: str):
 
 
 class BaseUploadWidget(ClearableFileInput):
-    def render(
-        self,
-        name: str,
-        value: UploadedFileTypes,
-        attrs=None,
-        renderer=None,
-    ):
-        upload_input = super().render(name, value, attrs, renderer)
-        return mark_safe(
-            render_to_string(
-                "django_file_form/upload_widget.html",
-                dict(
-                    input=upload_input,
-                    translations=json.dumps(TRANSLATIONS),
-                    uploaded_files=json.dumps(get_uploaded_files(value)),
-                ),
-            )
-        )
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['translations'] = json.dumps(TRANSLATIONS)
+        context['uploaded_files'] = json.dumps(get_uploaded_files(value))
+        return context
 
 
 class UploadWidget(BaseUploadWidget):

--- a/django_file_form/widgets.py
+++ b/django_file_form/widgets.py
@@ -95,8 +95,6 @@ class BaseUploadWidget(ClearableFileInput):
         context = super().get_context(name, value, attrs)
         context['translations'] = json.dumps(TRANSLATIONS)
         context['uploaded_files'] = json.dumps(get_uploaded_files(value))
-        # for backward compatibility
-        context['input'] = super().render(name, value, attrs, None)
         return context
 
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,6 +1,6 @@
 ## Customization
 
-### Override upload widget
+### Customize upload widget
 
 The `UploadWidget` and `UploadMultipleWidget` is rendered by a template `django_file_form/upload_widget.html`, which contains the `<input type="file">` widget and a few hidden fields
 for additional information.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,16 @@
+## Customization
+
+### Override upload widget
+
+The `UploadWidget` and `UploadMultipleWidget` is rendered by a template `django_file_form/upload_widget.html`, which contains the `<input type="file">` widget and a few hidden fields
+for additional information.
+
+You can customize the look and feel of the widget by overriding this template. Because
+Django by default does not use customized templates for form-rendering, you will need to
+
+1. Include `django.form` in `DJANGO_APPS`
+2. Add `FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'` to `settings.py`
+3. Add `django_file_form/upload_widget.html` to your projects `templates` directory
+  (or `jinja2` if you use jinja2 to render the templates). The upload widget will
+  be available as variable `widget` and you can use its attributes such as `widget.attrs.id`
+  to customize it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
     - Javascript options: javascript_options.md
     - Form sets: form_sets.md
     - Translations: translations.md
+    - Customization: customization.md
     - Javascript events: javascript_events.md
     - Internals: internals.md
     - Changelog: changelog.md


### PR DESCRIPTION
#421

Currently django-file-form overrides `render`, which does not allow user-customization at the widget level.

According to [django source code](https://github.com/django/django/blob/master/django/forms/widgets.py) and [documentation](https://docs.djangoproject.com/en/3.1/ref/forms/widgets/),, it seems better to extend `get_context` instead of `render` for the rendering the widget.

I tried to make the code backward compatible by including `input` in the `context`, but calling `render` inside `get_context` caused an infinite loop, so this PR is likely to be backward incompatible for users with their own `upload_widget.html`.

**NOTE**: With this change, it is a bit trickier to override the default template. Users would have to 

1. Add `django.form` to `DJANGO_APPS`,
2. Add `FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'` to settings.