### PR TITLE
Add AWS_S3_REGION_NAME and AWS_S3_SIGNATURE_VERSION options

### DIFF
--- a/django_file_form/s3_multipart/utils.py
+++ b/django_file_form/s3_multipart/utils.py
@@ -3,6 +3,7 @@ import time
 
 import boto3
 from botocore.exceptions import ClientError
+from botocore.client import Config
 from django.utils.crypto import get_random_string
 from storages.utils import setting, lookup_env
 
@@ -36,6 +37,8 @@ def file_form_upload_dir():
 
 
 def get_client():
+    signature_version = setting("AWS_SIGNATURE_VERSION", None)
+
     while True:
         try:
             # https://github.com/boto/boto3/issues/801
@@ -44,6 +47,7 @@ def get_client():
                 endpoint_url=get_endpoint_url(),
                 aws_access_key_id=get_access_key_id(),
                 aws_secret_access_key=get_secret_access_key(),
+                config=Config(signature_version=signature_version)
             )
         except:
             time.sleep(0.01)

--- a/django_file_form/s3_multipart/utils.py
+++ b/django_file_form/s3_multipart/utils.py
@@ -37,7 +37,7 @@ def file_form_upload_dir():
 
 
 def get_client():
-    signature_version = setting("AWS_SIGNATURE_VERSION", None)
+    signature_version = setting("AWS_S3_SIGNATURE_VERSION", None)
 
     while True:
         try:

--- a/django_file_form/s3_multipart/utils.py
+++ b/django_file_form/s3_multipart/utils.py
@@ -38,6 +38,7 @@ def file_form_upload_dir():
 
 def get_client():
     signature_version = setting("AWS_S3_SIGNATURE_VERSION", None)
+    region_name = setting("AWS_S3_REGION_NAME", None)
 
     while True:
         try:
@@ -47,7 +48,7 @@ def get_client():
                 endpoint_url=get_endpoint_url(),
                 aws_access_key_id=get_access_key_id(),
                 aws_secret_access_key=get_secret_access_key(),
-                config=Config(signature_version=signature_version)
+                config=Config(signature_version=signature_version, region_name=region_name)
             )
         except:
             time.sleep(0.01)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
   * Issue #211: auto initialize javascript
   * Issue #339: Django admin support
+  * Issue #446: add AWS_S3_REGION_NAME and AWS_S3_SIGNATURE_VERSION settings (thanks to Niklas Wahl)
 
 **3.1.4 (8 march 2021)**
 

--- a/docs/details.md
+++ b/docs/details.md
@@ -73,14 +73,15 @@ You then need to define the following variables in `settings`
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_STORAGE_BUCKET_NAME
-AWS_S3_REGION_NAME
-AWS_S3_ENDPOINT_URL
+AWS_S3_REGION_NAME (optional)
+AWS_S3_SIGNATURE_VERSION (optional)
+AWS_S3_ENDPOINT_URL (optional)
 ```
 
 or through environment variables with the same names as described
 in [`django-storage` documentation](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html).
 
-The following CORS settings are also needed in `settings`
+If you are using `django-csp` for setting the Content Security Policy, then the following CORS settings are also needed in `settings`
 ```
 CSP_DEFAULT_SRC = ("'none'",)
 CSP_STYLE_SRC = ("'self'")


### PR DESCRIPTION
Add options for the aws signature version and region:

```python
AWS_S3_SIGNATURE_VERSION = 's3v4'
AWS_S3_REGION_NAME = 'eu-central-1'
```

Also see
https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3.html#generating-presigned-urls and #446 