### PR TITLE
Added AWS_S3_REGION_NAME option

### DIFF
--- a/django_file_form/s3_multipart/utils.py
+++ b/django_file_form/s3_multipart/utils.py
@@ -38,6 +38,7 @@ def file_form_upload_dir():
 
 def get_client():
     signature_version = setting("AWS_S3_SIGNATURE_VERSION", None)
+    region_name = setting("AWS_S3_REGION_NAME", None)
 
     while True:
         try:
@@ -47,7 +48,7 @@ def get_client():
                 endpoint_url=get_endpoint_url(),
                 aws_access_key_id=get_access_key_id(),
                 aws_secret_access_key=get_secret_access_key(),
-                config=Config(signature_version=signature_version)
+                config=Config(signature_version=signature_version, region_name=region_name)
             )
         except:
             time.sleep(0.01)


### PR DESCRIPTION
The missing region_name option lead to an error when uploading with signature version s3v4