### PR TITLE
Make cache timeout configurable

### DIFF
--- a/django_file_form/conf.py
+++ b/django_file_form/conf.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 # in seconds
-TIMEOUT = 3600
+TIMEOUT = getattr(settings, 'FILE_FORM_CACHE_TIMEOUT', 3600)

--- a/django_file_form/conf.py
+++ b/django_file_form/conf.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 # in seconds
-TIMEOUT = getattr(settings, 'FILE_FORM_CACHE_TIMEOUT', 3600)
+TIMEOUT = getattr(settings, "FILE_FORM_CACHE_TIMEOUT", 3600)

--- a/django_file_form/conf.py
+++ b/django_file_form/conf.py
@@ -1,5 +1,5 @@
 from django.conf import settings
 
 
-# in seconds
-TIMEOUT = getattr(settings, "FILE_FORM_CACHE_TIMEOUT", 3600)
+# Cache timeout in seconds; default is 24 hours
+CACHE_TIMEOUT = getattr(settings, "FILE_FORM_CACHE_TIMEOUT", 3600 * 24)

--- a/django_file_form/tus/views.py
+++ b/django_file_form/tus/views.py
@@ -149,10 +149,16 @@ def upload_part(request, resource_id):
         response.status_code = 404
         return response
 
+    file_size_string = cache.get("tus-uploads/{}/file_size".format(resource_id))
+
+    if file_size_string is None:
+        response.status_code = 404
+        return response
+
     response["Upload-Offset"] = new_offset
     response.status_code = 204
 
-    file_size = int(cache.get("tus-uploads/{}/file_size".format(resource_id)))
+    file_size = int(file_size_string)
 
     if file_size == new_offset:
         remove_resource_from_cache(resource_id)

--- a/django_file_form/tus/views.py
+++ b/django_file_form/tus/views.py
@@ -48,11 +48,11 @@ def start_upload(request):
     cache.add(
         "tus-uploads/{}/filename".format(resource_id),
         metadata.get("filename"),
-        conf.TIMEOUT,
+        conf.CACHE_TIMEOUT,
     )
-    cache.add("tus-uploads/{}/file_size".format(resource_id), file_size, conf.TIMEOUT)
-    cache.add("tus-uploads/{}/offset".format(resource_id), 0, conf.TIMEOUT)
-    cache.add("tus-uploads/{}/metadata".format(resource_id), metadata, conf.TIMEOUT)
+    cache.add("tus-uploads/{}/file_size".format(resource_id), file_size, conf.CACHE_TIMEOUT)
+    cache.add("tus-uploads/{}/offset".format(resource_id), 0, conf.CACHE_TIMEOUT)
+    cache.add("tus-uploads/{}/metadata".format(resource_id), metadata, conf.CACHE_TIMEOUT)
 
     try:
         with safe_join(get_upload_path(), resource_id).open("wb") as f:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
   * Issue #471: Fix security advice: uncontrolled data used in path expression
+  * Issue #481: Make cache timeout configurable (thanks to Seb Haase)
 
 **3.2.2 (17 june 2021)**
 

--- a/docs/details.md
+++ b/docs/details.md
@@ -146,3 +146,13 @@ widgets and event handlers to update the `data` of this hidden field.
 
 Upon form submission, `django-file-form` retrieves the data and assign them to returned file
 objects with matching filename (could be of placeholder and other types) as `f.metadata`.
+
+
+## Cache
+
+Django-file-form uses the Django cache for storing data while uploading files.
+
+* Only meta data of the file is stored (including the upload progress), not contents of the file.
+* The default cache timeout is 24 hours. An upload will fail if it takes longer than that.
+* The timeout is configurable using the `FILE_FORM_CACHE_TIMEOUT` setting. See the 'Python settings' section.
+* The cache backed is configurable using `FILE_FORM_CACHE`.

--- a/docs/python_settings.md
+++ b/docs/python_settings.md
@@ -2,6 +2,10 @@
 
 Settings in `settings.py`:
 
+* **FILE_FORM_CACHE_TIMEOUT** (int)
+    * Cache timeout in seconds
+    * Default is 3600
+
 * **FILE_FORM_MUST_LOGIN** (True / False):
     * Must the user be logged in to upload a file.
     * The default is `False`.

--- a/docs/python_settings.md
+++ b/docs/python_settings.md
@@ -4,7 +4,7 @@ Settings in `settings.py`:
 
 * **FILE_FORM_CACHE_TIMEOUT** (int)
     * Cache timeout in seconds
-    * Default is 3600
+    * The Default is 24 hours
 
 * **FILE_FORM_MUST_LOGIN** (True / False):
     * Must the user be logged in to upload a file.

--- a/testproject/django_file_form_example/tests/live/test_with_ajax.py
+++ b/testproject/django_file_form_example/tests/live/test_with_ajax.py
@@ -605,6 +605,7 @@ class LiveTestCase(BaseLiveTestCase):
 
         temp_file = page.create_temp_file(b"a" * (2 ** 22), binary=True)
         page.upload_using_js(temp_file)
+        page.wait_until_upload_starts()
         page.cancel_upload()
         page.wait_until_upload_is_removed()
 


### PR DESCRIPTION
Make the cache timeout configurable using `FILE_FORM_CACHE_TIMEOUT`. Change the default timeout to 24 hours.

Also see #481