### PR TITLE
Fix missing error message

### DIFF
--- a/frontend/src/render_upload_file.ts
+++ b/frontend/src/render_upload_file.ts
@@ -244,7 +244,7 @@ class RenderUploadFile {
       return;
     }
 
-    const originalMessageSpan = document.querySelector(".dff-error");
+    const originalMessageSpan = el.querySelector(".dff-error");
     if (originalMessageSpan) {
       originalMessageSpan.remove();
     }


### PR DESCRIPTION
Hello @mbraak,

The first found error message is being deleted when a consecutive failed upload happens. Bellow you have an example for files that exceed the file upload size limit.

Before:
![Screenshot 2022-03-22 at 13 09 15](https://user-images.githubusercontent.com/19395810/159488782-d4ca0736-5760-4a05-965c-15b675dc1f0b.png)

After the fix:
![Screenshot 2022-03-22 at 13 29 37](https://user-images.githubusercontent.com/19395810/159488815-09eda4e2-5d07-4962-a23f-0295914b17ea.png)
