### PR TITLE
prevent uploading multiple files for a single file upload

### DIFF
--- a/frontend/src/file_field.ts
+++ b/frontend/src/file_field.ts
@@ -180,10 +180,12 @@ class FileField {
       }
 
       this.uploads = [];
-    }
 
-    for await (const file of files) {
-      await this.uploadFile(file);
+      await this.uploadFile(files[0]);
+    } else {
+      for await (const file of files) {
+        await this.uploadFile(file);
+      }
     }
 
     this.checkDropHint();


### PR DESCRIPTION
Hello @mbraak 

For a single file upload it's possible to drag and drop multiple files. That causes some issues with disappearing files when a form is invalid. It also might be slightly confusing for the users (I might had an issue when a first uploaded file was the one that was actually saved on a model).

My proposal is to upload only the first dropped file.

Video that shows the issue:

https://user-images.githubusercontent.com/19395810/221796902-371b19e8-d945-4655-a0d4-cfa72ce8647c.mov


