### PR TITLE
Fix empty FileField

### DIFF
--- a/django_file_form/uploaded_file.py
+++ b/django_file_form/uploaded_file.py
@@ -86,7 +86,10 @@ UploadedFileTypesOrList = Union[
 
 
 def get_initial_data_from_field_file(field_file: FieldFile) -> Dict:
-    return dict(name=field_file.name, size=field_file.size, type="existing")
+    try:
+        return dict(name=field_file.name, size=field_file.size, type="existing")
+    except:
+        return dict()
 
 
 def get_initial_data_from_uploaded_file(uploaded_file: UploadedFileTypes) -> Dict:


### PR DESCRIPTION
In the case of a ModelForm where there is a FileField (or ImageField) not required (blank=True, null=True), django-file-form fails on update with the following error:

```
"The '%s' attribute has no file associated with it." % self.field.name
```
It happens because django ModelForm provides a FileField instance with no associated file, so `field_file.size` fails.