### PR TITLE
Use request.get_full_path() for response upload Location header.

### DIFF
--- a/django_file_form/tus/views.py
+++ b/django_file_form/tus/views.py
@@ -73,7 +73,7 @@ def start_upload(request):
         return response
 
     response.status_code = 201
-    response["Location"] = "{}{}".format(request.build_absolute_uri(), resource_id)
+    response["Location"] = "{}{}".format(request.get_full_path(), resource_id)
     response["ResourceId"] = resource_id
     return response
 


### PR DESCRIPTION
When Django production deploy in behind a reverse proxy, i.e. Apache, if  don't use the directive `proxy_redirect` the header `Location` on `tus` upoad response can create [Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default) problems.

So I suggest to replace the use of `request.get_full_path()` instead of `request.build_absolute_uri()`