### PR TITLE
Use manifest storage in test project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         run: npm run test
       - name: Create javascript coverage directory
         run: mkdir js_coverage
+      - name: Collect static files
+        run: python manage.py collectstatic --no-input
+        working-directory: testproject
       - name: Test with coverage
         run: COVERAGE=true coverage run --source=django_file_form,testproject/django_file_form_example testproject/manage.py test django_file_form_example -v 2
       - name: Merge Python coverage

--- a/testproject/django_file_form_example/tests/utils/base_live_testcase.py
+++ b/testproject/django_file_form_example/tests/utils/base_live_testcase.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from uuid import uuid4
 from django.conf import settings
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import LiveServerTestCase
 from django.test.selenium import SeleniumTestCase, SeleniumTestCaseBase
 
 from .test_utils import write_json
@@ -21,7 +21,7 @@ class SeleniumTestMetaClass(SeleniumTestCaseBase):
         return options
 
 
-class BaseLiveTestCase(SeleniumTestCase, StaticLiveServerTestCase, metaclass=SeleniumTestMetaClass):
+class BaseLiveTestCase(SeleniumTestCase, LiveServerTestCase, metaclass=SeleniumTestMetaClass):
     browsers = ['chrome']
     headless = True
     page_class = None

--- a/testproject/testproject/settings_default.py
+++ b/testproject/testproject/settings_default.py
@@ -110,3 +110,12 @@ CSP_CONNECT_SRC = ("'self'", AWS_S3_ENDPOINT_URL)
 
 if "COVERAGE" in os.environ:
     CSP_SCRIPT_SRC += ["'unsafe-eval'"]
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}


### PR DESCRIPTION
Using manifest storage can cause errors with collectstatic in real life projects. Therefore test with manifest storage so we can detect these errors.