### PR TITLE
Fix aws region in S3 tests

### DIFF
--- a/testproject/django_file_form_example/tests/live/test_s3.py
+++ b/testproject/django_file_form_example/tests/live/test_s3.py
@@ -60,11 +60,12 @@ class S3TestCase(BaseLiveTestCase):
             endpoint_url="http://localhost:4566",
             aws_access_key_id="access1",
             aws_secret_access_key="test1",
+            region_name="eu-west-1"
         )
         bucket = s3.Bucket("mybucket")
 
         bucket.create(
-            CreateBucketConfiguration={"LocationConstraint": "us_east1"},
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
         )
 
         cls.bucket = bucket


### PR DESCRIPTION
S3 tests can fail when aws is configured on the machine. Fix this by explicitly configuring a region for S3 in tests.